### PR TITLE
update to support 16-bit address memory

### DIFF
--- a/usmbus/__init__.py
+++ b/usmbus/__init__.py
@@ -14,14 +14,14 @@ class SMBus(I2C):
         Hopefully this will allow you to run code that was targeted at
         py-smbus unmodified on micropython.
 
-	    Use it like you would the machine.I2C class:
+        Use it like you would the machine.I2C class:
 
             import usmbus.SMBus
 
-            bus = SMBus(1, pins=('G15','G10'), baudrate=100000)
+            bus = SMBus(id=0, scl=machine.Pin(15), sda=machine.Pin(10), freq=100000)
             bus.read_byte_data(addr, register)
             ... etc
-	"""
+    """
 
     def read_byte_data(self, addr, register):
         """ Read a single byte from register of device at addr
@@ -31,7 +31,16 @@ class SMBus(I2C):
     def read_i2c_block_data(self, addr, register, length):
         """ Read a block of length from register of device at addr
             Returns a bytes object filled with whatever was read """
-        return self.readfrom_mem(addr, register, length)
+        register_size = 8
+        if isinstance(register, list):
+            temp = 0
+            register_size = 0
+            for r in bytes(register):
+                temp <<= 8
+                temp |= r
+                register_size += 8
+            register = temp
+        return self.readfrom_mem(addr, register, length, addrsize=register_size)
 
     def write_byte_data(self, addr, register, data):
         """ Write a single byte from buffer `data` to register of device at addr
@@ -45,11 +54,24 @@ class SMBus(I2C):
         """ Write multiple bytes of data to register of device at addr
             Returns None """
         # writeto_mem() expects something it can treat as a buffer
-        if isinstance(data, int):
-            data = bytes([data])
-        return self.writeto_mem(addr, register, data)
+        if not isinstance(data, bytes):
+            if not isinstance(data, list):
+                data = [data]
+            data = bytes(data)
 
-    # The follwing haven't been implemented, but could be.
+        register_size = 8
+        if isinstance(register, list):
+            temp = 0
+            register_size = 0
+            for r in bytes(register):
+                temp <<= 8
+                temp |= r
+                register_size += 8
+            register = temp
+
+        return self.writeto_mem(addr, register, data, addrsize=register_size)
+
+    # The following haven't been implemented, but could be.
     def read_byte(self, *args, **kwargs):
         """ Not yet implemented """
         raise RuntimeError("Not yet implemented")
@@ -65,4 +87,4 @@ class SMBus(I2C):
     def write_word_data(self, *args, **kwargs):
         """ Not yet implemented """
         raise RuntimeError("Not yet implemented")
-        
+


### PR DESCRIPTION
* Changes as in this PR from @matteius : https://github.com/geoffklee/micropython-smbus/pull/5
* update `read_i2c_block_data` & `write_i2c_block_data` to support 16 bit memory addresses.